### PR TITLE
removed spaces from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-  bazel-bin
-  bazel-genfiles
-  bazel-out
-  bazel-proto_library
-  bazel-testlogs
+bazel-bin
+bazel-genfiles
+bazel-out
+bazel-proto_library
+bazel-testlogs


### PR DESCRIPTION
after running `bazel build` I still had the bazel-* dirs showing as untracked. Removing the spaces fixes this.