### PR TITLE
Fix example for later bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,18 +1,18 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # proto_library, cc_proto_library, and java_proto_library rules implicitly
 # depend on @com_google_protobuf for protoc and proto runtimes.
 # This statement defines the @com_google_protobuf repo.
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30",
-    strip_prefix = "protobuf-3.5.0",
-    urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
-)
+    strip_prefix = "protobuf-3.6.1.3",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.tar.gz"],
+    )
 
 # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite//:javalite_toolchain,
 # which is the JavaLite proto runtime (base classes and common utilities).
 http_archive(
     name = "com_google_protobuf_javalite",
-    sha256 = "d8a2fed3708781196f92e1e7e7e713cf66804bd2944894401057214aff4f468e",
-    strip_prefix = "protobuf-5e8916e881c573c5d83980197a6f783c132d4276",
-    urls = ["https://github.com/google/protobuf/archive/5e8916e881c573c5d83980197a6f783c132d4276.zip"],
-)
+    strip_prefix = "protobuf-javalite",
+    urls = ["https://github.com/google/protobuf/archive/javalite.zip"],
+    )


### PR DESCRIPTION
**Background**
Cloning and attempting to use this example repo breaks:
```
ERROR: /Users/snapsam/code/proto_library/WORKSPACE:4:1: name 'http_archive' is not defined
ERROR: /Users/snapsam/code/proto_library/WORKSPACE:13:1: name 'http_archive' is not defined
ERROR: Error evaluating WORKSPACE file
ERROR: error loading package '': Encountered error while reading extension file 'tools/build_defs/repo/http.bzl': no such package '@bazel_tools//tools/build_defs/repo': error loading package 'external': Could not load //external package
ERROR: error loading package '': Encountered error while reading extension file 'tools/build_defs/repo/http.bzl': no such package '@bazel_tools//tools/build_defs/repo': error loading package 'external': Could not load //external package
INFO: Elapsed time: 0.296s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
```

Fixing http_archive gives the next error:

```
ERROR: /private/var/tmp/_bazel_snapsam/c0003f367b02e98a87175911e30b666a/external/com_google_protobuf/BUILD:597:1: Traceback (most recent call last):
        File "/private/var/tmp/_bazel_snapsam/c0003f367b02e98a87175911e30b666a/external/com_google_protobuf/BUILD", line 597
                internal_gen_well_known_protos_java(srcs = WELL_KNOWN_PROTOS)
        File "/private/var/tmp/_bazel_snapsam/c0003f367b02e98a87175911e30b666a/external/com_google_protobuf/protobuf.bzl", line 266, in internal_gen_well_known_protos_java
                Label(("%s//protobuf_java" % REPOSITOR...))
        File "/private/var/tmp/_bazel_snapsam/c0003f367b02e98a87175911e30b666a/external/com_google_protobuf/protobuf.bzl", line 266, in Label
                REPOSITORY_NAME
The value 'REPOSITORY_NAME' has been removed in favor of 'repository_name()', please use the latter (https://docs.bazel.build/versions/master/skylark/lib/native.html#repository_name).
INFO: An error occurred during the fetch of repository 'com_google_protobuf_javalite'
INFO: Call stack for the definition of repository 'com_google_protobuf_javalite':
 - /Users/snapsam/code/proto_library/WORKSPACE:15:1
ERROR: /Users/snapsam/code/proto_library/src/BUILD:52:1: every rule of type proto_library implicitly depends upon the target '@com_google_protobuf//:protoc', but this target could not be found because of: Target '@com_go
ogle_protobuf//:protoc' contains an error and its package is in error
ERROR: /Users/snapsam/code/proto_library/src/BUILD:46:1: every rule of type proto_library implicitly depends upon the target '@com_google_protobuf//:protoc', but this target could not be found because of: Target '@com_go
ogle_protobuf//:protoc' contains an error and its package is in error
ERROR: /Users/snapsam/code/proto_library/src/BUILD:32:1: Target '@com_google_protobuf//:any_proto' contains an error and its package is in error and referenced by '//src:person_proto'
ERROR: /Users/snapsam/code/proto_library/src/BUILD:32:1: every rule of type proto_library implicitly depends upon the target '@com_google_protobuf//:protoc', but this target could not be found because of: Target '@com_go
ogle_protobuf//:protoc' contains an error and its package is in error
ERROR: Analysis of target '//src:zip_code_proto' failed; build aborted: Analysis failed
INFO: Elapsed time: 2.218s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (6 packages loaded, 34 targets configured)
```

Both of these are due to incompatibility with recent versions of bazel.  The
former is a problem in this repository's WORKSPACE, where as the latter is a
problem in the dependency

**Change**
 * Provide a drop-in replacement for http_archive
 * Upgrade proto dependencies to working version [see](https://github.com/protocolbuffers/protobuf/pull/4650)

**Test Plan**
 - [x] Compiles locally with Bazel 0.25.2