### PR TITLE
Update com_google_protobuf_javalite reference to use v3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 This Bazel demonstrates how to use Bazel's built-in support for
 [Protocol Buffers](https://developers.google.com/protocol-buffers/).
 
-> :bangbang: Before Bazel 3.0, `java_lite_proto_library` had an implicit
-  dependency on `@com_google_protobuf_javalite//:javalite_toolchain`. Check
-  [here](https://github.com/cgrushko/proto_library/blob/08e5522a99c41a188046e1f5af305d5c5d39c2d9/WORKSPACE#L38)
-  for an example how to use `java_lite_proto_library` with Bazel 2.2 (or earlier).
-
 ```bash
 $ bazel build //src:person_java_proto_lite
 Target //src:person_java_proto up-to-date:
@@ -26,4 +21,20 @@ Target //src:person_java_proto up-to-date:
   bazel-genfiles/src/person_proto-descriptor-set.proto.bin
 ```
 
-_Tested with Bazel 3.0._
+## Supporting Bazel 2.x and earlier
+
+Before Bazel 3.0, `java_lite_proto_library` had an implicit dependency on `@com_google_protobuf_javalite//:javalite_toolchain`. In order to support
+Bazel 2.x and earlier, you need to provide this dependency. Because the
+java lite toolchain has been included in the main protobuf repo since v3.11,
+it is recommended to use v3.11 at a minimum in order to support both Bazel 3.x
+and Bazel 2.x. To do this, add this to your WORKSPACE file:
+
+```
+# The 'com_google_protobuf_javalite' package is required for Bazel 2.x and below.
+http_archive(
+    name = "com_google_protobuf_javalite",
+    sha256 = "832c476bb442ca98a59c2291b8a504648d1c139b74acc15ef667a0e8f5e984e7",
+    strip_prefix = "protobuf-3.11.3",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.3.zip"],
+)
+```


### PR DESCRIPTION
The com_google_protobuf_javalite example in Readme.md uses an old java lite toolchain,
which is not compatible with the 3.11 runtime that is used by rules_proto. Update the
docs to have com_google_protobuf_javalite use the 3.11 toolchain so projects can build
with both Bazel 3.x and 2.x.